### PR TITLE
Fix hanging when exiting game from full screen

### DIFF
--- a/Client/Program.cs
+++ b/Client/Program.cs
@@ -12,6 +12,7 @@ namespace Client
         public static AMain PForm;
 
         public static bool Restart;
+        public static bool Launch;
 
         [STAThread]
         private static void Main(string[] args)
@@ -42,8 +43,14 @@ namespace Client
 
                 CheckResolutionSetting();
 
-                if (Settings.P_Patcher) Application.Run(PForm = new Launcher.AMain());
-                else Application.Run(Form = new CMain());
+                Launch = false;
+                if (Settings.P_Patcher)
+                    Application.Run(PForm = new AMain());
+                else
+                    Launch = true;
+
+                if (Launch)
+                    Application.Run(Form = new CMain());
 
                 Settings.Save();
 


### PR DESCRIPTION
Remove unnecessary compression code.
Download response as async.
MoveOldFilesToCurrent is already called in Close event.