### PR TITLE
Better frame skipping Fix #691

### DIFF
--- a/Client/MirObjects/Effect.cs
+++ b/Client/MirObjects/Effect.cs
@@ -80,7 +80,7 @@ namespace Client.MirObjects
 
             if (CMain.Time <= NextFrame) return;
 
-            if (Owner != null && Owner.SkipFrames) CurrentFrame++;
+            var skip = (Owner != null && Owner.SkipFrames);
 
             if (++CurrentFrame >= Count)
             {
@@ -89,11 +89,20 @@ namespace Client.MirObjects
                     CurrentFrame = 0;
                     Start = CMain.Time + Delay;
                     NextFrame = Start + (Duration / Count) * (CurrentFrame + 1);
+
+                    if (skip)
+                        NextFrame = NextFrame / 2;
                 }
                 else
                     Remove();
             }
-            else NextFrame = Start + (Duration / Count) * (CurrentFrame + 1);
+            else
+            {
+                NextFrame = Start + (Duration / Count) * (CurrentFrame + 1);
+
+                if (skip)
+                    NextFrame = NextFrame / 2;
+            }
 
             GameScene.Scene.MapControl.TextureValid = false;
         }

--- a/Client/MirObjects/MonsterObject.cs
+++ b/Client/MirObjects/MonsterObject.cs
@@ -1260,53 +1260,73 @@ namespace Client.MirObjects
         {
             if (Frame == null) return;
 
+            if (!GameScene.CanMove && !SkipFrames)
+            {
+                switch (CurrentAction)
+                {
+                    case MirAction.Walking:
+                    case MirAction.Running:
+                    case MirAction.Pushed:
+                        return;
+                }
+            }
+
             switch (CurrentAction)
             {
                 case MirAction.Walking:
-                    if (!GameScene.CanMove) return;
-
                     GameScene.Scene.MapControl.TextureValid = false;
 
-                    if (UpdateFrame() >= Frame.Count)
+                    if (CMain.Time >= NextMotion)
                     {
-                        FrameIndex = Frame.Count - 1;
-                        SetAction();
-                    }
-                    else
-                    {
-                        switch (FrameIndex)
+                        if (UpdateFrame() >= Frame.Count)
                         {
-                            case 1:
-                                PlayWalkSound(true);
-                                break;
-                            case 4:
-                                PlayWalkSound(false);
-                                break;
+                            FrameIndex = Frame.Count - 1;
+                            SetAction();
+                        }
+                        else
+                        {
+                            switch (FrameIndex)
+                            {
+                                case 1:
+                                    PlayWalkSound(true);
+                                    break;
+                                case 4:
+                                    PlayWalkSound(false);
+                                    break;
+                            }
+
+                            NextMotion += FrameInterval;
                         }
                     }
                     break;
                 case MirAction.Running:
-                    if (!GameScene.CanMove) return;
-
                     GameScene.Scene.MapControl.TextureValid = false;
 
-                    if (UpdateFrame() >= Frame.Count)
+                    if (CMain.Time >= NextMotion)
                     {
-                        FrameIndex = Frame.Count - 1;
-                        SetAction();
+                        if (UpdateFrame() >= Frame.Count)
+                        {
+                            FrameIndex = Frame.Count - 1;
+                            SetAction();
+                        }
+                        else
+                            NextMotion += FrameInterval;
                     }
                     break;
                 case MirAction.Pushed:
-                    if (!GameScene.CanMove) return;
-
                     GameScene.Scene.MapControl.TextureValid = false;
 
-                    FrameIndex -= 2;
-
-                    if (FrameIndex < 0)
+                    if (CMain.Time >= NextMotion)
                     {
-                        FrameIndex = 0;
-                        SetAction();
+                        FrameIndex -= 2;
+
+                        if (FrameIndex < 0)
+                        {
+                            FrameIndex = 0;
+                            SetAction();
+                        }
+                        else
+                            NextMotion += FrameInterval;
                     }
                     break;
                 case MirAction.Jump:

--- a/Client/MirObjects/MonsterObject.cs
+++ b/Client/MirObjects/MonsterObject.cs
@@ -512,6 +512,11 @@ namespace Client.MirObjects
                 if (Frame == null) return false;
 
                 FrameInterval = Frame.Interval;
+
+                if (SkipFrames)
+                {
+                    FrameInterval = FrameInterval / 2;
+                }
             }
             else
             {
@@ -630,6 +635,11 @@ namespace Client.MirObjects
                 if (Frame == null) return false;
 
                 FrameInterval = Frame.Interval;
+
+                if (SkipFrames)
+                {
+                    FrameInterval = FrameInterval / 2;
+                }
 
                 Point front = Functions.PointMove(CurrentLocation, Direction, 1);
 
@@ -1257,8 +1267,6 @@ namespace Client.MirObjects
 
                     GameScene.Scene.MapControl.TextureValid = false;
 
-                    if (SkipFrames) UpdateFrame();
-
                     if (UpdateFrame() >= Frame.Count)
                     {
                         FrameIndex = Frame.Count - 1;
@@ -1281,8 +1289,6 @@ namespace Client.MirObjects
                     if (!GameScene.CanMove) return;
 
                     GameScene.Scene.MapControl.TextureValid = false;
-
-                    if (SkipFrames) UpdateFrame();
 
                     if (UpdateFrame() >= Frame.Count)
                     {
@@ -1308,8 +1314,6 @@ namespace Client.MirObjects
                     {
                         GameScene.Scene.MapControl.TextureValid = false;
 
-                        if (SkipFrames) UpdateFrame();
-
                         if (UpdateFrame() >= Frame.Count)
                         {
                             FrameIndex = Frame.Count - 1;
@@ -1325,8 +1329,6 @@ namespace Client.MirObjects
                     if (CMain.Time >= NextMotion)
                     {
                         GameScene.Scene.MapControl.TextureValid = false;
-
-                        if (SkipFrames) UpdateFrame();
 
                         if (UpdateFrame() >= Frame.Count)
                         {
@@ -1356,8 +1358,6 @@ namespace Client.MirObjects
                     if (CMain.Time >= NextMotion)
                     {
                         GameScene.Scene.MapControl.TextureValid = false;
-
-                        if (SkipFrames) UpdateFrame();
 
                         if (UpdateFrame() >= Frame.Count)
                         {
@@ -1417,8 +1417,6 @@ namespace Client.MirObjects
                     {
                         GameScene.Scene.MapControl.TextureValid = false;
 
-                        if (SkipFrames) UpdateFrame();
-
                         if (UpdateFrame() >= Frame.Count)
                         {
                             switch (BaseImage)
@@ -1469,8 +1467,6 @@ namespace Client.MirObjects
                     {
                         GameScene.Scene.MapControl.TextureValid = false;
 
-                        if (SkipFrames) UpdateFrame();
-
                         if (UpdateFrame() >= Frame.Count)
                         {
                             if (CurrentAction == MirAction.Standing)
@@ -1504,8 +1500,6 @@ namespace Client.MirObjects
                         GameScene.Scene.MapControl.TextureValid = false;
 
                         Point front = Functions.PointMove(CurrentLocation, Direction, 1);
-
-                        if (SkipFrames) UpdateFrame();
 
                         if (UpdateFrame() >= Frame.Count)
                         {
@@ -1819,8 +1813,6 @@ namespace Client.MirObjects
                     {
                         GameScene.Scene.MapControl.TextureValid = false;
 
-                        if (SkipFrames) UpdateFrame();
-
                         if (UpdateFrame() >= Frame.Count)
                         {
                             FrameIndex = Frame.Count - 1;
@@ -1836,8 +1828,6 @@ namespace Client.MirObjects
                     if (CMain.Time >= NextMotion)
                     {
                         GameScene.Scene.MapControl.TextureValid = false;
-
-                        if (SkipFrames) UpdateFrame();
 
                         Point front = Functions.PointMove(CurrentLocation, Direction, 1);
 
@@ -2125,8 +2115,6 @@ namespace Client.MirObjects
                     {
                         GameScene.Scene.MapControl.TextureValid = false;
 
-                        if (SkipFrames) UpdateFrame();
-
                         if (UpdateFrame() >= Frame.Count)
                         {
                             FrameIndex = Frame.Count - 1;
@@ -2276,11 +2264,8 @@ namespace Client.MirObjects
                     {
                         GameScene.Scene.MapControl.TextureValid = false;
 
-                        if (SkipFrames) UpdateFrame();
-
                         if (UpdateFrame() >= Frame.Count)
                         {
-                            
                             FrameIndex = Frame.Count - 1;
                             SetAction();
                         }
@@ -2341,8 +2326,6 @@ namespace Client.MirObjects
                     {
                         GameScene.Scene.MapControl.TextureValid = false;
 
-                        if (SkipFrames) UpdateFrame();
-
                         if (UpdateFrame() >= Frame.Count)
                         {
                             FrameIndex = Frame.Count - 1;
@@ -2372,8 +2355,6 @@ namespace Client.MirObjects
                     if (CMain.Time >= NextMotion)
                     {
                         GameScene.Scene.MapControl.TextureValid = false;
-
-                        if (SkipFrames) UpdateFrame();
 
                         if (UpdateFrame() >= Frame.Count)
                         {
@@ -3356,8 +3337,6 @@ namespace Client.MirObjects
                     {
                         GameScene.Scene.MapControl.TextureValid = false;
 
-                        if (SkipFrames) UpdateFrame();
-
                         if (UpdateFrame() >= Frame.Count)
                         {
                             FrameIndex = Frame.Count - 1;
@@ -3588,8 +3567,6 @@ namespace Client.MirObjects
                     {
                         GameScene.Scene.MapControl.TextureValid = false;
 
-                        if (SkipFrames) UpdateFrame();
-
                         if (UpdateFrame() >= Frame.Count)
                         {
                             FrameIndex = Frame.Count - 1;
@@ -3624,8 +3601,6 @@ namespace Client.MirObjects
                     {
                         GameScene.Scene.MapControl.TextureValid = false;
 
-                        if (SkipFrames) UpdateFrame();
-
                         if (UpdateFrame() >= Frame.Count)
                         {
                             FrameIndex = Frame.Count - 1;
@@ -3642,8 +3617,6 @@ namespace Client.MirObjects
                     if (CMain.Time >= NextMotion)
                     {
                         GameScene.Scene.MapControl.TextureValid = false;
-
-                        if (SkipFrames) UpdateFrame();
 
                         if (UpdateFrame() >= Frame.Count)
                         {
@@ -3742,8 +3715,6 @@ namespace Client.MirObjects
                     if (CMain.Time >= NextMotion)
                     {
                         GameScene.Scene.MapControl.TextureValid = false;
-
-                        if (SkipFrames) UpdateFrame();
 
                         if (UpdateFrame() >= Frame.Count)
                         {

--- a/Client/MirObjects/NPCObject.cs
+++ b/Client/MirObjects/NPCObject.cs
@@ -83,6 +83,7 @@ namespace Client.MirObjects
         public override void Process()
         {
             bool update = CMain.Time >= NextMotion || GameScene.CanMove;
+            SkipFrames = ActionFeed.Count > 1;
 
             ProcessFrames();
 
@@ -178,8 +179,6 @@ namespace Client.MirObjects
                     {
                         GameScene.Scene.MapControl.TextureValid = false;
 
-                        if (SkipFrames) UpdateFrame();
-
                         if (UpdateFrame() >= Frame.Count)
                         {
                             FrameIndex = Frame.Count - 1;
@@ -195,8 +194,6 @@ namespace Client.MirObjects
                     if (CMain.Time >= NextMotion2)
                     {
                         GameScene.Scene.MapControl.TextureValid = false;
-
-                        if (SkipFrames) UpdateFrame2();
 
                         if (UpdateFrame2() >= Frame.EffectCount)
                             EffectFrameIndex = Frame.EffectCount - 1;
@@ -261,6 +258,12 @@ namespace Client.MirObjects
 
                 FrameInterval = Frame.Interval;
                 EffectFrameInterval = Frame.EffectInterval;
+
+                if (SkipFrames)
+                {
+                    FrameInterval = FrameInterval / 2;
+                    EffectFrameInterval = EffectFrameInterval / 2;
+                }
             }
             else
             {
@@ -280,6 +283,12 @@ namespace Client.MirObjects
 
                 FrameInterval = Frame.Interval;
                 EffectFrameInterval = Frame.EffectInterval;
+
+                if (SkipFrames)
+                {
+                    FrameInterval = FrameInterval / 2;
+                    EffectFrameInterval = EffectFrameInterval / 2;
+                }
             }
 
             NextMotion = CMain.Time + FrameInterval;

--- a/Client/MirObjects/PlayerObject.cs
+++ b/Client/MirObjects/PlayerObject.cs
@@ -972,6 +972,12 @@ namespace Client.MirObjects
                 FrameInterval = Frame.Interval;
                 EffectFrameInterval = Frame.EffectInterval;
 
+                if (SkipFrames)
+                {
+                    FrameInterval = FrameInterval / 2;
+                    EffectFrameInterval = EffectFrameInterval / 2;
+                }
+
                 SetLibraries();
             }
             else
@@ -1320,6 +1326,12 @@ namespace Client.MirObjects
 
                 FrameInterval = Frame.Interval;
                 EffectFrameInterval = Frame.EffectInterval;
+
+                if (SkipFrames)
+                {
+                    FrameInterval = FrameInterval / 2;
+                    EffectFrameInterval = EffectFrameInterval / 2;
+                }
 
                 if (this == User)
                 {
@@ -2333,9 +2345,6 @@ namespace Client.MirObjects
 
                     if (this == User) GameScene.Scene.MapControl.FloorValid = false;
                     //if (CMain.Time < NextMotion) return;
-                    if (SkipFrames) UpdateFrame();
-
-
 
                     if (UpdateFrame(false) >= Frame.Count)
                     {
@@ -2358,8 +2367,6 @@ namespace Client.MirObjects
                     {
                         if (this == User) GameScene.Scene.MapControl.TextureValid = false;
 
-                        if (SkipFrames) UpdateFrame2();
-
                         if (UpdateFrame2() >= Frame.EffectCount)
                             EffectFrameIndex = Frame.EffectCount - 1;
                         else
@@ -2370,7 +2377,7 @@ namespace Client.MirObjects
                     if (!GameScene.CanMove) return;
                     GameScene.Scene.MapControl.TextureValid = false;
                     if (this == User) GameScene.Scene.MapControl.FloorValid = false;
-                    if (SkipFrames) UpdateFrame();
+
                     if (UpdateFrame() >= Frame.Count)
                     {
                         FrameIndex = Frame.Count - 1;
@@ -2387,8 +2394,6 @@ namespace Client.MirObjects
                     if (WingEffect > 0 && CMain.Time >= NextMotion2)
                     {
                         if (this == User) GameScene.Scene.MapControl.TextureValid = false;
-
-                        if (SkipFrames) UpdateFrame2();
 
                         if (UpdateFrame2() >= Frame.EffectCount)
                             EffectFrameIndex = Frame.EffectCount - 1;
@@ -2454,8 +2459,6 @@ namespace Client.MirObjects
                     {
                         GameScene.Scene.MapControl.TextureValid = false;
 
-                        if (SkipFrames) UpdateFrame();
-
                         if (UpdateFrame() >= Frame.Count)
                         {
                             FrameIndex = Frame.Count - 1;
@@ -2471,8 +2474,6 @@ namespace Client.MirObjects
                     {
                         GameScene.Scene.MapControl.TextureValid = false;
 
-                        if (SkipFrames) UpdateFrame2();
-
                         if (UpdateFrame2() >= Frame.EffectCount)
                             EffectFrameIndex = Frame.EffectCount - 1;
                         else
@@ -2487,8 +2488,6 @@ namespace Client.MirObjects
                     if (CMain.Time >= NextMotion)
                     {
                         GameScene.Scene.MapControl.TextureValid = false;
-
-                        if (SkipFrames) UpdateFrame();
 
                         if (UpdateFrame() >= Frame.Count)
                         {
@@ -2540,8 +2539,6 @@ namespace Client.MirObjects
                     {
                         GameScene.Scene.MapControl.TextureValid = false;
 
-                        if (SkipFrames) UpdateFrame2();
-
                         if (UpdateFrame2() >= Frame.EffectCount)
                             EffectFrameIndex = Frame.EffectCount - 1;
                         else
@@ -2558,8 +2555,6 @@ namespace Client.MirObjects
                     if (CMain.Time >= NextMotion)
                     {
                         GameScene.Scene.MapControl.TextureValid = false;
-
-                        if (SkipFrames) UpdateFrame();
 
                         if (UpdateFrame() >= Frame.Count)
                         {
@@ -2581,8 +2576,6 @@ namespace Client.MirObjects
                     {
                         GameScene.Scene.MapControl.TextureValid = false;
 
-                        if (SkipFrames) UpdateFrame2();
-
                         if (UpdateFrame2() >= Frame.EffectCount)
                             EffectFrameIndex = Frame.EffectCount - 1;
                         else
@@ -2594,8 +2587,6 @@ namespace Client.MirObjects
                     if (CMain.Time >= NextMotion)
                     {
                         GameScene.Scene.MapControl.TextureValid = false;
-
-                        if (SkipFrames) UpdateFrame();
 
                         if (UpdateFrame() >= Frame.Count)
                         {
@@ -2640,8 +2631,6 @@ namespace Client.MirObjects
                     {
                         GameScene.Scene.MapControl.TextureValid = false;
 
-                        if (SkipFrames) UpdateFrame2();
-
                         if (UpdateFrame2() >= Frame.EffectCount)
                             EffectFrameIndex = Frame.EffectCount - 1;
                         else
@@ -2653,8 +2642,6 @@ namespace Client.MirObjects
                     if (CMain.Time >= NextMotion)
                     {
                         GameScene.Scene.MapControl.TextureValid = false;
-
-                        if (SkipFrames) UpdateFrame();
 
                         if (UpdateFrame() >= Frame.Count)
                         {
@@ -2879,8 +2866,6 @@ namespace Client.MirObjects
                     {
                         GameScene.Scene.MapControl.TextureValid = false;
 
-                        if (SkipFrames) UpdateFrame2();
-
                         if (UpdateFrame2() >= Frame.EffectCount)
                             EffectFrameIndex = Frame.EffectCount - 1;
                         else
@@ -2893,8 +2878,6 @@ namespace Client.MirObjects
                     if (CMain.Time >= NextMotion)
                     {
                         GameScene.Scene.MapControl.TextureValid = false;
-
-                        if (SkipFrames) UpdateFrame();
 
                         if (UpdateFrame() >= Frame.Count)
                         {
@@ -2910,8 +2893,6 @@ namespace Client.MirObjects
                     {
                         GameScene.Scene.MapControl.TextureValid = false;
 
-                        if (SkipFrames) UpdateFrame2();
-
                         if (UpdateFrame2() >= Frame.EffectCount)
                             EffectFrameIndex = Frame.EffectCount - 1;
                         else
@@ -2922,8 +2903,6 @@ namespace Client.MirObjects
                     if (CMain.Time >= NextMotion)
                     {
                         GameScene.Scene.MapControl.TextureValid = false;
-
-                        if (SkipFrames) UpdateFrame();
 
                         if (UpdateFrame() >= Frame.Count)
                         {
@@ -3541,8 +3520,6 @@ namespace Client.MirObjects
                     {
                         GameScene.Scene.MapControl.TextureValid = false;
 
-                        if (SkipFrames) UpdateFrame2();
-
                         if (UpdateFrame2() >= Frame.EffectCount)
                             EffectFrameIndex = Frame.EffectCount - 1;
                         else
@@ -3553,8 +3530,6 @@ namespace Client.MirObjects
                     if (CMain.Time >= NextMotion)
                     {
                         GameScene.Scene.MapControl.TextureValid = false;
-
-                        if (SkipFrames) UpdateFrame();
 
                         if (UpdateFrame() >= Frame.Count)
                         {
@@ -3575,8 +3550,6 @@ namespace Client.MirObjects
                     {
                         GameScene.Scene.MapControl.TextureValid = false;
 
-                        if (SkipFrames) UpdateFrame2();
-
                         if (UpdateFrame2() >= Frame.EffectCount)
                             EffectFrameIndex = Frame.EffectCount - 1;
                         else
@@ -3589,8 +3562,6 @@ namespace Client.MirObjects
                     if (CMain.Time >= NextMotion)
                     {
                         GameScene.Scene.MapControl.TextureValid = false;
-
-                        if (SkipFrames) UpdateFrame();
 
                         if (UpdateFrame() >= Frame.Count)
                         {

--- a/Client/MirObjects/PlayerObject.cs
+++ b/Client/MirObjects/PlayerObject.cs
@@ -2330,6 +2330,24 @@ namespace Client.MirObjects
         {
             if (Frame == null) return;
 
+            if (!GameScene.CanMove && !SkipFrames)
+            {
+                switch (CurrentAction)
+                {
+                    case MirAction.Walking:
+                    case MirAction.Running:
+                    case MirAction.MountWalking:
+                    case MirAction.MountRunning:
+                    case MirAction.Pushed:
+                    case MirAction.DashL:
+                    case MirAction.DashR:
+                    case MirAction.Sneek:
+                    case MirAction.Jump:
+                    case MirAction.DashAttack:
+                        return;
+                }
+            }
+
             switch (CurrentAction)
             {
                 case MirAction.Walking:
@@ -2338,29 +2356,26 @@ namespace Client.MirObjects
                 case MirAction.MountRunning:
                 case MirAction.Sneek:
                 case MirAction.DashAttack:
-                    if (!GameScene.CanMove) return;
-                    
-
-                    GameScene.Scene.MapControl.TextureValid = false;
-
-                    if (this == User) GameScene.Scene.MapControl.FloorValid = false;
-                    //if (CMain.Time < NextMotion) return;
-
-                    if (UpdateFrame(false) >= Frame.Count)
+                    if (CMain.Time >= NextMotion)
                     {
+                        GameScene.Scene.MapControl.TextureValid = false;
 
+                        if (this == User) GameScene.Scene.MapControl.FloorValid = false;
 
-                        FrameIndex = Frame.Count - 1;
-                        SetAction();
-                    }
-                    else
-                    {
-                        if (this == User)
+                        if (UpdateFrame(false) >= Frame.Count)
                         {
-                            if (FrameIndex == 1 || FrameIndex == 4)
-                                PlayStepSound();
+                            FrameIndex = Frame.Count - 1;
+                            SetAction();
                         }
-                        //NextMotion += FrameInterval;
+                        else
+                        {
+                            if (this == User)
+                            {
+                                if (FrameIndex == 1 || FrameIndex == 4)
+                                    PlayStepSound();
+                            }
+                            NextMotion += FrameInterval;
+                        }
                     }
 
                     if (WingEffect > 0 && CMain.Time >= NextMotion2)
@@ -2374,21 +2389,25 @@ namespace Client.MirObjects
                     }
                     break;
                  case MirAction.Jump:
-                    if (!GameScene.CanMove) return;
-                    GameScene.Scene.MapControl.TextureValid = false;
-                    if (this == User) GameScene.Scene.MapControl.FloorValid = false;
+                    if (CMain.Time >= NextMotion)
+                    {
+                        GameScene.Scene.MapControl.TextureValid = false;
+                        if (this == User) GameScene.Scene.MapControl.FloorValid = false;
 
-                    if (UpdateFrame() >= Frame.Count)
-                    {
-                        FrameIndex = Frame.Count - 1;
-                        SetAction();
-                    }
-                    else
-                    {
-                        if (FrameIndex == 1)
-                            SoundManager.PlaySound(20000 + 127 * 10 + (Gender == MirGender.Male ? 5 : 6));
-                        if (FrameIndex == 7)
-                            SoundManager.PlaySound(20000 + 127 * 10 + 7);
+                        if (UpdateFrame() >= Frame.Count)
+                        {
+                            FrameIndex = Frame.Count - 1;
+                            SetAction();
+                        }
+                        else
+                        {
+                            if (FrameIndex == 1)
+                                SoundManager.PlaySound(20000 + 127 * 10 + (Gender == MirGender.Male ? 5 : 6));
+                            if (FrameIndex == 7)
+                                SoundManager.PlaySound(20000 + 127 * 10 + 7);
+
+                            NextMotion += FrameInterval;
+                        }
                     }
                     //Backstep wingeffect
                     if (WingEffect > 0 && CMain.Time >= NextMotion2)
@@ -2402,51 +2421,60 @@ namespace Client.MirObjects
                     }
                     break;
                 case MirAction.DashL:
-                    if (!GameScene.CanMove) return;
-
-                    GameScene.Scene.MapControl.TextureValid = false;
-
-                    if (this == User) GameScene.Scene.MapControl.FloorValid = false;
-                    if (UpdateFrame() >= 3)
+                    if (CMain.Time >= NextMotion)
                     {
-                        FrameIndex = 2;
-                        SetAction();
-                    }
+                        GameScene.Scene.MapControl.TextureValid = false;
 
-                    if (UpdateFrame2() >= 3) EffectFrameIndex = 2;
+                        if (this == User) GameScene.Scene.MapControl.FloorValid = false;
+                        if (UpdateFrame() >= 3)
+                        {
+                            FrameIndex = 2;
+                            SetAction();
+                        }
+                        else
+                            NextMotion += FrameInterval;
+
+                        if (UpdateFrame2() >= 3) EffectFrameIndex = 2;
+                    }
                     break;
                 case MirAction.DashR:
-                    if (!GameScene.CanMove) return;
-
-                    GameScene.Scene.MapControl.TextureValid = false;
-
-                    if (this == User) GameScene.Scene.MapControl.FloorValid = false;
-
-                    if (UpdateFrame() >= 6)
+                    if (CMain.Time >= NextMotion)
                     {
-                        FrameIndex = 5;
-                        SetAction();
-                    }
+                        GameScene.Scene.MapControl.TextureValid = false;
 
-                    if (UpdateFrame2() >= 6) EffectFrameIndex = 5;
+                        if (this == User) GameScene.Scene.MapControl.FloorValid = false;
+
+                        if (UpdateFrame() >= 6)
+                        {
+                            FrameIndex = 5;
+                            SetAction();
+                        }
+                        else
+                            NextMotion += FrameInterval;
+
+                        if (UpdateFrame2() >= 6) EffectFrameIndex = 5;
+                    }
                     break;
                 case MirAction.Pushed:
-                    if (!GameScene.CanMove) return;
-
-                    GameScene.Scene.MapControl.TextureValid = false;
-
-                    if (this == User) GameScene.Scene.MapControl.FloorValid = false;
-
-                    FrameIndex -= 2;
-                    EffectFrameIndex -= 2;
-
-                    if (FrameIndex < 0)
+                    if (CMain.Time >= NextMotion)
                     {
-                        FrameIndex = 0;
-                        SetAction();
-                    }
+                        GameScene.Scene.MapControl.TextureValid = false;
 
-                    if (FrameIndex < 0) EffectFrameIndex = 0;
+                        if (this == User) GameScene.Scene.MapControl.FloorValid = false;
+
+                        FrameIndex -= 2;
+                        EffectFrameIndex -= 2;
+
+                        if (FrameIndex < 0)
+                        {
+                            FrameIndex = 0;
+                            SetAction();
+                        }
+                        else
+                            NextMotion += FrameInterval;
+
+                        if (EffectFrameIndex < 0) EffectFrameIndex = 0;
+                    }
                     break;
 
                 case MirAction.Standing:


### PR DESCRIPTION
Instead of skipping frames, it will speed up actions.
Frame skipping could only occur when NextAction was valid, which could cause more delays