### PR TITLE
Elements, trees and more

### DIFF
--- a/Client/MirObjects/MonsterObject.cs
+++ b/Client/MirObjects/MonsterObject.cs
@@ -2533,18 +2533,6 @@ namespace Client.MirObjects
                                                     };
                                                 }
                                                 break;
-
-
-
-
-
-
-
-
-
-
-
-
                                             case Monster.AxeSkeleton:
                                                 if (MapControl.GetObject(TargetID) != null)
                                                     CreateProjectile(224, Libraries.Monsters[(ushort)Monster.AxeSkeleton], false, 3, 30, 0);

--- a/Server/MirObjects/HumanObject.cs
+++ b/Server/MirObjects/HumanObject.cs
@@ -3202,7 +3202,7 @@ namespace Server.MirObjects
                     magic = GetMagic(spell);
                     damageFinal = magic.GetDamage(damageBase);
                     ob.Attacked(this, damageFinal,
-                        ob is MonsterObject && (ob.Name == "ElectricElement" || ob.Name == "CloudElement") ? DefenceType.Repulsion : DefenceType.Agility, 
+                        ob is MonsterObject monster && (monster.Info.AI == 49) ? DefenceType.Repulsion : DefenceType.Agility, 
                         false);
                     break;
                 }
@@ -4827,8 +4827,7 @@ namespace Server.MirObjects
                                 if (target.IsAttackTarget(this))
                                 {
                                         if (target.Attacked(this, j <= 1 ? damageFinal : (int)(damageFinal * 0.6),
-                                            target is MonsterObject && (target.Name == "ElectricElement"
-                                            || target.Name == "CloudElement") ? DefenceType.Repulsion : DefenceType.MAC,
+                                            target is MonsterObject monster && (monster.Info.AI == 49) ? DefenceType.Repulsion : DefenceType.MAC,
                                             false) > 0)
                                             train = true;
                                 }

--- a/Server/MirObjects/HumanObject.cs
+++ b/Server/MirObjects/HumanObject.cs
@@ -3196,12 +3196,14 @@ namespace Server.MirObjects
                 for (int i = 0; i < cell.Objects.Count; i++)
                 {
                     MapObject ob = cell.Objects[i];
-                    if (ob.Race != ObjectType.Player && ob.Race != ObjectType.Monster) continue;
+                    if (ob.Race != ObjectType.Player && ob.Race != ObjectType.Monster && ob.Race != ObjectType.Hero) continue;
                     if (!ob.IsAttackTarget(this)) continue;
 
                     magic = GetMagic(spell);
                     damageFinal = magic.GetDamage(damageBase);
-                    ob.Attacked(this, damageFinal, DefenceType.Agility, false);
+                    ob.Attacked(this, damageFinal,
+                        ob is MonsterObject && (ob.Name == "ElectricElement" || ob.Name == "CloudElement") ? DefenceType.Repulsion : DefenceType.Agility, 
+                        false);
                     break;
                 }
 
@@ -3948,7 +3950,7 @@ namespace Server.MirObjects
                         for (int i = 0; cell.Objects != null && i < cell.Objects.Count; i++)
                         {
                             MapObject ob = cell.Objects[i];
-                            if (ob.Race != ObjectType.Monster && ob.Race != ObjectType.Player) continue;
+                            if (ob.Race != ObjectType.Monster && ob.Race != ObjectType.Player && ob.Race != ObjectType.Hero) continue;
 
                             if (!ob.IsAttackTarget(this) || ob.Level >= Level) continue;
 
@@ -3968,6 +3970,7 @@ namespace Server.MirObjects
                                     ((PlayerObject)ob).BindLocation = szi.Location;
                                     ((PlayerObject)ob).BindMapIndex = CurrentMapIndex;
                                     ob.InSafeZone = true;
+
                                 }
                                 else
                                     ob.InSafeZone = false;
@@ -4819,11 +4822,15 @@ namespace Server.MirObjects
                         {
                             case ObjectType.Monster:
                             case ObjectType.Player:
+                            case ObjectType.Hero:
                                 //Only targets
                                 if (target.IsAttackTarget(this))
                                 {
-                                    if (target.Attacked(this, j <= 1 ? damageFinal : (int)(damageFinal * 0.6), DefenceType.MAC, false) > 0)
-                                        train = true;
+                                        if (target.Attacked(this, j <= 1 ? damageFinal : (int)(damageFinal * 0.6),
+                                            target is MonsterObject && (target.Name == "ElectricElement"
+                                            || target.Name == "CloudElement") ? DefenceType.Repulsion : DefenceType.MAC,
+                                            false) > 0)
+                                            train = true;
                                 }
                                 break;
                         }
@@ -4884,6 +4891,7 @@ namespace Server.MirObjects
                 {
                     break;
                 }
+
 
                 // acquire target
                 if (i == 0)
@@ -4987,11 +4995,13 @@ namespace Server.MirObjects
 
                             if (IsAttackTarget(ob.Caster))
                             {
-                                switch(ob.Spell)
+                                switch (ob.Spell)
                                 {
                                     case Spell.FireWall:
-                                        Attacked((PlayerObject)ob.Caster, ob.Value, DefenceType.MAC, false);
+                                        if (Attacked((PlayerObject)ob.Caster, ob.Value, DefenceType.MAC, false) > 0)
+                                        {
                                         _blocking = true;
+                                        }
                                         break;
                                 }
                             }
@@ -5532,7 +5542,7 @@ namespace Server.MirObjects
 
             if (target.CurrentLocation.Y < 0 || target.CurrentLocation.Y >= CurrentMap.Height || target.CurrentLocation.X < 0 || target.CurrentLocation.X >= CurrentMap.Height) return;
 
-            if (target.Race != ObjectType.Monster && target.Race != ObjectType.Player) return;
+            if (target.Race != ObjectType.Monster && target.Race != ObjectType.Player && target.Race != ObjectType.Hero) return;
             if (!target.IsAttackTarget(this) || target.Level >= Level) return;
 
             if (Envir.Random.Next(20) >= 6 + magic.Level * 3 + ElementsLevel + Level - target.Level) return;

--- a/Server/MirObjects/Monsters/ThunderElement.cs
+++ b/Server/MirObjects/Monsters/ThunderElement.cs
@@ -1,4 +1,5 @@
 ﻿using Server.MirDatabase;
+using System.Drawing;
 using S = ServerPackets;
 
 namespace Server.MirObjects.Monsters
@@ -36,6 +37,14 @@ namespace Server.MirObjects.Monsters
 
             if (InAttackRange() && CanAttack)
             {
+                if (Envir.Random.Next(3) == 1)
+                {
+                    int targetXOffset, targetYOffset;
+                    targetXOffset = Envir.Random.Next(-1, 2);
+                    targetYOffset = Envir.Random.Next(-1, 2);
+                    Point point = new Point(Target.CurrentLocation.X + targetXOffset, Target.CurrentLocation.Y + targetYOffset);
+                    MoveTo(point);
+                }
                 Attack();
                 return;
             }
@@ -85,8 +94,16 @@ namespace Server.MirObjects.Monsters
 
             if (result > 0)
             {
-                if (pusher is PlayerObject) Attacked((PlayerObject)pusher, Math.Max(50, Envir.Random.Next(Stats[Stat.HP])), DefenceType.Repulsion);
-                else if (pusher is MonsterObject) Attacked((MonsterObject)pusher, Math.Max(50, Envir.Random.Next(Stats[Stat.HP])), DefenceType.Repulsion);
+                int damage;
+                damage = distance * (Math.Max(50, (Envir.Random.Next(Stats[Stat.HP]) / 5)));
+                if (pusher is PlayerObject)
+                {
+                    //int damage = Math.Max(50, Envir.Random.Next(Stats[Stat.HP]));
+                    Attacked((PlayerObject)pusher, damage, DefenceType.Repulsion);
+                    pusher.ReceiveChat("Distance: " + distance.ToString() + ", " + "Damage: " + damage.ToString() + ", HP remaining: " + HP.ToString(), ChatType.Normal);
+
+                }
+                else if (pusher is MonsterObject) Attacked((MonsterObject)pusher, damage, DefenceType.Repulsion);
             }
             return result;
         }

--- a/Server/MirObjects/Monsters/ThunderElement.cs
+++ b/Server/MirObjects/Monsters/ThunderElement.cs
@@ -100,8 +100,6 @@ namespace Server.MirObjects.Monsters
                 {
                     //int damage = Math.Max(50, Envir.Random.Next(Stats[Stat.HP]));
                     Attacked((PlayerObject)pusher, damage, DefenceType.Repulsion);
-                    pusher.ReceiveChat("Distance: " + distance.ToString() + ", " + "Damage: " + damage.ToString() + ", HP remaining: " + HP.ToString(), ChatType.Normal);
-
                 }
                 else if (pusher is MonsterObject) Attacked((MonsterObject)pusher, damage, DefenceType.Repulsion);
             }

--- a/Server/MirObjects/Monsters/Tree.cs
+++ b/Server/MirObjects/Monsters/Tree.cs
@@ -36,25 +36,35 @@ namespace Server.MirObjects.Monsters
         {
             int armour = 0;
 
-            switch (type)
+            //switch (type)
+            //{
+            //    case DefenceType.ACAgility:
+            //        if (Envir.Random.Next(Stats[Stat.Agility] + 1) > attacker.Stats[Stat.Accuracy]) return 0;
+            //        armour = GetAttackPower(Stats[Stat.MinAC], Stats[Stat.MaxAC]);
+            //        break;
+            //    case DefenceType.AC:
+            //        armour = GetAttackPower(Stats[Stat.MinAC], Stats[Stat.MaxAC]);
+            //        break;
+            //    case DefenceType.MACAgility:
+            //        if (Envir.Random.Next(Stats[Stat.Agility] + 1) > attacker.Stats[Stat.Accuracy]) return 0;
+            //        armour = GetAttackPower(Stats[Stat.MinMAC], Stats[Stat.MaxMAC]);
+            //        break;
+            //    case DefenceType.MAC:
+            //        armour = GetAttackPower(Stats[Stat.MinMAC], Stats[Stat.MaxMAC]);
+            //        break;
+            //    case DefenceType.Agility:
+            //        if (Envir.Random.Next(Stats[Stat.Agility] + 1) > attacker.Stats[Stat.Accuracy]) return 0;
+            //        break;
+            //}
+
+            if (type != DefenceType.ACAgility)
             {
-                case DefenceType.ACAgility:
-                    if (Envir.Random.Next(Stats[Stat.Agility] + 1) > attacker.Stats[Stat.Accuracy]) return 0;
-                    armour = GetAttackPower(Stats[Stat.MinAC], Stats[Stat.MaxAC]);
-                    break;
-                case DefenceType.AC:
-                    armour = GetAttackPower(Stats[Stat.MinAC], Stats[Stat.MaxAC]);
-                    break;
-                case DefenceType.MACAgility:
-                    if (Envir.Random.Next(Stats[Stat.Agility] + 1) > attacker.Stats[Stat.Accuracy]) return 0;
-                    armour = GetAttackPower(Stats[Stat.MinMAC], Stats[Stat.MaxMAC]);
-                    break;
-                case DefenceType.MAC:
-                    armour = GetAttackPower(Stats[Stat.MinMAC], Stats[Stat.MaxMAC]);
-                    break;
-                case DefenceType.Agility:
-                    if (Envir.Random.Next(Stats[Stat.Agility] + 1) > attacker.Stats[Stat.Accuracy]) return 0;
-                    break;
+                return 0;
+            }
+            else
+            {
+                if (Envir.Random.Next(Stats[Stat.Agility] + 1) > attacker.Stats[Stat.Accuracy]) return 0;
+                armour = GetAttackPower(Stats[Stat.MinAC], Stats[Stat.MaxAC]);
             }
 
             if (armour >= damage) return 0;
@@ -93,25 +103,35 @@ namespace Server.MirObjects.Monsters
         {
             int armour = 0;
 
-            switch (type)
+            //switch (type)
+            //{
+            //    case DefenceType.ACAgility:
+            //        if (Envir.Random.Next(Stats[Stat.Agility] + 1) > attacker.Stats[Stat.Accuracy]) return 0;
+            //        armour = GetAttackPower(Stats[Stat.MinAC], Stats[Stat.MaxAC]);
+            //        break;
+            //    case DefenceType.AC:
+            //        armour = GetAttackPower(Stats[Stat.MinAC], Stats[Stat.MaxAC]);
+            //        break;
+            //    case DefenceType.MACAgility:
+            //        if (Envir.Random.Next(Stats[Stat.Agility] + 1) > attacker.Stats[Stat.Accuracy]) return 0;
+            //        armour = GetAttackPower(Stats[Stat.MinMAC], Stats[Stat.MaxMAC]);
+            //        break;
+            //    case DefenceType.MAC:
+            //        armour = GetAttackPower(Stats[Stat.MinMAC], Stats[Stat.MaxMAC]);
+            //        break;
+            //    case DefenceType.Agility:
+            //        if (Envir.Random.Next(Stats[Stat.Agility] + 1) > attacker.Stats[Stat.Accuracy]) return 0;
+            //        break;
+            //}
+
+            if (type != DefenceType.ACAgility)
             {
-                case DefenceType.ACAgility:
-                    if (Envir.Random.Next(Stats[Stat.Agility] + 1) > attacker.Stats[Stat.Accuracy]) return 0;
-                    armour = GetAttackPower(Stats[Stat.MinAC], Stats[Stat.MaxAC]);
-                    break;
-                case DefenceType.AC:
-                    armour = GetAttackPower(Stats[Stat.MinAC], Stats[Stat.MaxAC]);
-                    break;
-                case DefenceType.MACAgility:
-                    if (Envir.Random.Next(Stats[Stat.Agility] + 1) > attacker.Stats[Stat.Accuracy]) return 0;
-                    armour = GetAttackPower(Stats[Stat.MinMAC], Stats[Stat.MaxMAC]);
-                    break;
-                case DefenceType.MAC:
-                    armour = GetAttackPower(Stats[Stat.MinMAC], Stats[Stat.MaxMAC]);
-                    break;
-                case DefenceType.Agility:
-                    if (Envir.Random.Next(Stats[Stat.Agility] + 1) > attacker.Stats[Stat.Accuracy]) return 0;
-                    break;
+                return 0;
+            }
+            else
+            {
+                if (Envir.Random.Next(Stats[Stat.Agility] + 1) > attacker.Stats[Stat.Accuracy]) return 0;
+                armour = GetAttackPower(Stats[Stat.MinAC], Stats[Stat.MaxAC]);
             }
 
             if (armour >= damage) return 0;


### PR DESCRIPTION
- BA and Thrusting now damage Cloud/Elec Elements
- Changed the way Elements take damage due to the way SD works (applies damage every cell moved), as SD was one-shotting Elements due to massive damage.
- Elements now move around their target at random.
- FW now only interrupts dash if the target actually takes damage.
- Heroes now take damage from Thrusting and BA.
- Heroes can now be Repulsed.
- Heroes can now be knocked back by ElementalShot
- Trees/Mushrooms can now only be damaged by physical attacks, not magic.