### PR TITLE
Fix for guild creation item dropdown list

### DIFF
--- a/Server.MirForms/Systems/GuildInfoForm.cs
+++ b/Server.MirForms/Systems/GuildInfoForm.cs
@@ -69,8 +69,16 @@ namespace Server
                 if (Settings.Guild_CreationCostList[GuildCreateListcomboBox.SelectedIndex].Item == null)
                     GuildItemNamecomboBox.SelectedIndex = 0;
                 else
-                    GuildItemNamecomboBox.SelectedIndex = Settings.Guild_CreationCostList[GuildCreateListcomboBox.SelectedIndex].Item.Index;
-                GuildAmounttextBox.Text = Settings.Guild_CreationCostList[GuildCreateListcomboBox.SelectedIndex].Amount.ToString();
+                {
+                    if (Envir.GetItemInfo(Settings.Guild_CreationCostList[GuildCreateListcomboBox.SelectedIndex].Item.Index) != null)
+                    {
+                        GuildItemNamecomboBox.SelectedItem = Envir.GetItemInfo(Settings.Guild_CreationCostList[GuildCreateListcomboBox.SelectedIndex].Item.Index);
+                    }
+                    else
+                    {
+                        GuildItemNamecomboBox.SelectedIndex = 0;
+                    }
+                }
             }
             if (BuffList.SelectedItem == null)
             {


### PR DESCRIPTION
- UpdateGuildInterface() now sets the guild item combo box's selected value/item using SelectedItem == UserItem (if found), rather than item index.