### PR TITLE
Stacked gems ghosting fix

### DIFF
--- a/Client/MirScenes/GameScene.cs
+++ b/Client/MirScenes/GameScene.cs
@@ -2411,7 +2411,10 @@ namespace Client.MirScenes
 
             if (!p.Success) return;
 
-            fromCell.Item = null;
+            if (fromCell.Item.Count > 1)
+                fromCell.Item.Count--;
+            else
+                fromCell.Item = null;
 
             switch (p.Grid)
             {


### PR DESCRIPTION
Stacks of consumables of type 'Gem' no longer ghost in bag after using one.