### PR TITLE
QoL changes

### DIFF
--- a/Client/MirObjects/MapObject.cs
+++ b/Client/MirObjects/MapObject.cs
@@ -481,7 +481,8 @@ namespace Client.MirObjects
             switch (Race)
             {
                 case ObjectType.Player:
-                    if (GroupDialog.GroupList.Contains(name)) index = 10;
+                    index = 12;
+                    if (GroupDialog.GroupList.Contains(name) && name != User.Name) index = 10;
                     break;
                 case ObjectType.Monster:
                     if (GroupDialog.GroupList.Contains(name) || name == User.Name) index = 11;

--- a/Client/MirScenes/Dialogs/CharacterDialog.cs
+++ b/Client/MirScenes/Dialogs/CharacterDialog.cs
@@ -651,7 +651,7 @@ namespace Client.MirScenes.Dialogs
             StatusButton.Index = -1;
             StateButton.Index = -1;
             SkillButton.Index = 503;
-            StartIndex = 0;
+            //StartIndex = 0;
         }
 
         private void RefreshInterface()

--- a/Client/MirScenes/GameScene.cs
+++ b/Client/MirScenes/GameScene.cs
@@ -10760,6 +10760,15 @@ namespace Client.MirScenes
                     MapObject.TargetObject.DrawBlend();
             }
 
+                        if (Settings.Effect)
+            {
+                for (int i = Effects.Count - 1; i >= 0; i--)
+                {
+                    if (Effects[i].DrawBehind) continue;
+                    Effects[i].Draw();
+                }
+            }
+
             foreach (var ob in Objects.Values)
             {
                 ob.DrawEffects(Settings.Effect);
@@ -10768,18 +10777,14 @@ namespace Client.MirScenes
                     ob.DrawName();
 
                 ob.DrawChat();
-                ob.DrawHealth();
+                //ob.DrawHealth();
                 ob.DrawPoison();
                 ob.DrawDamages();
             }
 
-            if (Settings.Effect)
+            foreach (var ob in Objects.Values)
             {
-                for (int i = Effects.Count - 1; i >= 0; i--)
-                {
-                    if (Effects[i].DrawBehind) continue;
-                    Effects[i].Draw();
-                }
+                ob.DrawHealth();
             }
         }
 


### PR DESCRIPTION
- Skill page now opens on the last page the player looked at
- Added comma separator mask to Trust Merchant price text box
- User's HP bar now draw over effects to make them easier to see in big lures/lots of effects
- User's HP bar is green instead of red to differentiate from mobs
- User's HP bar is now green when grouped instead of blue to differentiate from other group members

<img width="1280" height="800" alt="HP QoL before 1" src="https://github.com/user-attachments/assets/d4d39805-34dc-4301-8f6b-c682750a4b0d" />
<img width="1280" height="800" alt="HP QoL before 2" src="https://github.com/user-attachments/assets/0bd03fd6-97ee-4263-8e2f-8c94a7e7f466" />
<img width="1280" height="800" alt="HP QoL after 1" src="https://github.com/user-attachments/assets/6d17dc02-e278-4104-b51f-ce5bb5433509" />
<img width="1280" height="800" alt="HP QoL after 2" src="https://github.com/user-attachments/assets/a816f534-c5b1-4f44-8146-7e953e9457fe" />
